### PR TITLE
Linux shell escaping; cross-distro compatible term

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function compile(treePath) {
   if (atom.config.get("gpp-compiler.fileExtensnion") != "") {
     info.name += "." + atom.config.get("gpp-compiler.fileExtensnion");
   }
-  exec(esc(["g++", info.base, "-o", info.name, atom.config.get("gpp-compiler.gppOptions")]), {cwd: info.dir}, function(err, stdout, stderr) {
+  exec(esc(["g++", info.base, "-o", info.name]) + " " + atom.config.get("gpp-compiler.gppOptions"), {cwd: info.dir}, function(err, stdout, stderr) {
     if (stderr) {
       atom.notifications.add("error", stderr.replace(/\n/g, "<br>"));
       if (atom.config.get("gpp-compiler.addCompilingErr")) {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 /* globals atom */
 "use strict";
 var exec = require("child_process").exec;
+var esc = require("shell-escape");
 var fs = require("fs");
 var parse = require("path").parse;
 
@@ -47,7 +48,7 @@ function compile(treePath) {
   if (atom.config.get("gpp-compiler.fileExtensnion") != "") {
     info.name += "." + atom.config.get("gpp-compiler.fileExtensnion");
   }
-  exec("g++ \"" + info.base + "\" -o \"" + info.name + "\" " + atom.config.get("gpp-compiler.gppOptions"), {cwd: info.dir}, function(err, stdout, stderr) {
+  exec(esc(["g++", info.base, "-o", info.name, atom.config.get("gpp-compiler.gppOptions")]), {cwd: info.dir}, function(err, stdout, stderr) {
     if (stderr) {
       atom.notifications.add("error", stderr.replace(/\n/g, "<br>"));
       if (atom.config.get("gpp-compiler.addCompilingErr")) {
@@ -60,7 +61,7 @@ function compile(treePath) {
             cwd: info.dir
           });
         } else if (process.platform == "linux") {
-          exec("gnome-terminal -e \"./" + info.name.replace(/ /g, "\\ ") + "\"", {cwd: info.dir});
+          exec(esc(["xterm", "-hold", "-e", "./" + info.name]), {cwd: info.dir});
         } else if (process.platform == "darwin") {
           exec("open \"" + info.name.replace(/ /g, "\\ ") + "\"");
         }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "engines": {
     "atom": ">=1.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+		"shell-escape": "0.2.0"
+	},
   "readme": "# gpp-compiler package\n\nWith this package, you can compile and run c++ code from within Atom.\n\nTo compile a file, press F5 while or right click the file in tree view and click \"Compile and run\"\n\n## What you need\n- g++\n\nIf you're on Windows, you will need to add g++ to your PATH.\n\nIf you're on Mac, Google how to install g++.\n\nIf you're on Linux, g++ should already be installed.\n",
   "readmeFilename": "README.md",
   "bugs": {


### PR DESCRIPTION
If you name files in bizarre ways, say, `foo${bar}.cpp`, the filenames have to be correctly escaped. 

Most distros don't have `gnome-terminal`; everyone should have `xterm`. A more proper fix might be to use `x-terminal-emulator` or `xdg-terminal`, depending on which is installed, and falling back to `xterm` if all else fails. That would break the `-hold` argument, though. For whatever reason, this is a Hard Problem for Linux. 

I haven't tested this on OS X or Windows, since I do not have machines to test on. 