### PR TITLE
Support for changing shell for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,17 @@ if (process.platform === "linux") {
     };
 }
 
+if (process.platform === "win32") {
+  module.
+    exports.
+    config.
+    windowsLaunchOptions = {
+      default: "cmd /C",
+      title: "Launch Commands on Windows",
+      type: "string"
+    };
+}
+
 function debug(...args) {
   if (atom.config.get("gpp-compiler.debug")) {
     console.info(...args);
@@ -400,7 +411,7 @@ function compile(command, info, args, gdb) {
           // we can't use child_process.spawn), which spawns a new instance of
           // cmd to run the program
           const file = getCompiledPath(info.dir, info.name);
-          const command = `start "${info.name}" cmd /C "${gdb ? "gdb" : ""} ${file} ${gdb ? "" : "& echo. & pause"}`;
+          const command = `start "${info.name}" ${atom.config.get("gpp-compiler.windowsLaunchOptions")} "${gdb ? "gdb" : ""} ${file} ${gdb ? "" : "& echo. & pause"}`;
 
           debug("command", command);
           child_process.exec(command, options);


### PR DESCRIPTION
- Added option to change default "cmd /C" for running on Windows
- Defaults on "cmd /C"
- User can specify custom shells such as ConEmu