### PR TITLE
Fix bugs when using clang compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,7 +200,13 @@ function getCompiledPath(dir, base) {
   if (atom.config.get("gpp-compiler.compileToTmpDirectory")) {
     return path.join(os.tmpdir(), base);
   } else {
-    return path.join(dir, base);
+    const flag = atom.config.get("gpp-compiler.cppCompiler");
+    if (flag == "clang" || flag == "clang++") {
+      return path.join(dir,(base + ".exe"));
+    }
+    else {
+      return path.join(dir, base);
+    }
   }
 }
 


### PR DESCRIPTION
I use clang in windows 10 with visual studio 2015.
When I set “C Compiler” to clang, the gpp compiler can successfully compile and run C files without bugs.
But I can not run C++ files like above.
I set "C++ Compiler" to "clang++" or "clang" and without extra options, then gpp compiler successfully compiled the file but can not run after compile in cmd window, says "XX is not recognized as an internal or external command "
Finally, I fixed this bug with a change of source code in index.js -> getCompiledPath():
```js
function getCompiledPath(dir, base) {
  debug("getCompiledPath()", dir, base);

  if (atom.config.get("gpp-compiler.compileToTmpDirectory")) {
    return path.join(os.tmpdir(), base);
  } else {
    const flag = atom.config.get("gpp-compiler.cppCompiler");
    if (flag == "clang" || flag == "clang++") {
      return path.join(dir,(base + ".exe"));
    }
    else {
      return path.join(dir, base);
    }
  }
}
```

Just a little change:)