### PR TITLE
Add autoCloseNotifications option

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ function compileFile(fileType, gdb) {
       notifications.
       addError(
         "<strong>File not found.</strong><br/>Save before compiling.",
-        {dismissable: atom.config.get("gpp-compiler.autoCloseNotifications")}
+        {dismissable: !atom.config.get("gpp-compiler.autoCloseNotifications")}
       );
   }
 }
@@ -303,7 +303,7 @@ function compile(command, info, args, gdb) {
         notifications.
         addError(
           stderr.replace(/\n/g, "<br/>"),
-          {dismissable: atom.config.get("gpp-compiler.autoCloseNotifications")}
+          {dismissable: !atom.config.get("gpp-compiler.autoCloseNotifications")}
         );
 
       if (atom.config.get("gpp-compiler.addCompilingErr")) {
@@ -314,7 +314,7 @@ function compile(command, info, args, gdb) {
       if (stderr && atom.config.get("gpp-compiler.showWarnings")) {
         atom.notifications.addWarning(
           stderr.replace(/\n/g, "<br/>"),
-          {dismissable: atom.config.get("gpp-compiler.autoCloseNotifications")}
+          {dismissable: !atom.config.get("gpp-compiler.autoCloseNotifications")}
         );
       }
 

--- a/index.js
+++ b/index.js
@@ -88,6 +88,11 @@ module.exports = {
       default: true,
       title: "Compile to Temporary Directory",
       type: "boolean"
+    },
+    autoCloseNotifications: {
+      default: false,
+      title: "Automatically close notifications",
+      type: "boolean"
     }
   },
   deactivate() {
@@ -221,7 +226,10 @@ function compileFile(fileType, gdb) {
   } else {
     atom.
       notifications.
-      addError("<strong>File not found.</strong><br/>Save before compiling.");
+      addError(
+        "<strong>File not found.</strong><br/>Save before compiling.",
+        {dismissable: atom.config.get("gpp-compiler.autoCloseNotifications")}
+      );
   }
 }
 
@@ -293,7 +301,10 @@ function compile(command, info, args, gdb) {
     if (code) {
       atom.
         notifications.
-        addError(stderr.replace(/\n/g, "<br/>"));
+        addError(
+          stderr.replace(/\n/g, "<br/>"),
+          {dismissable: atom.config.get("gpp-compiler.autoCloseNotifications")}
+        );
 
       if (atom.config.get("gpp-compiler.addCompilingErr")) {
         fs.writeFile(path.join(info.dir, "compiling_error.txt"), stderr);
@@ -301,7 +312,10 @@ function compile(command, info, args, gdb) {
     } else {
       // compilation was successful, but there still may be warnings
       if (stderr && atom.config.get("gpp-compiler.showWarnings")) {
-        atom.notifications.addWarning(stderr.replace(/\n/g, "<br/>"));
+        atom.notifications.addWarning(
+          stderr.replace(/\n/g, "<br/>"),
+          {dismissable: atom.config.get("gpp-compiler.autoCloseNotifications")}
+        );
       }
 
       // if the user wants the program to run after compilation, run it in their


### PR DESCRIPTION
I've added an option that allows the user to control whether notifications with warnings and errors are automatically dismissed. By default the notifications get dismissed after 5 seconds.