### PR TITLE
Fix issue with closing GNOME Terminal

### DIFF
--- a/keymaps/gpp-compiler.json
+++ b/keymaps/gpp-compiler.json
@@ -1,5 +1,5 @@
 {
-  "atom-text-editor": {
+  "atom-text-editor[data-grammar~=\"c\"], atom-text-editor[data-grammar~=\"cpp\"]": {
     "f5": "gpp-compiler:compile",
     "f6": "gpp-compiler:gdb"
   }


### PR DESCRIPTION
Adds an option to hold the terminal window open (fixes #42).

This is important for GNOME Terminal users who don't want to put up with that annoying blue bar (#31)

Also removes some periods from preference description strings for consistency.