### PR TITLE
Added important reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ For Arch-based distros, run `sudo pacman -S gcc`.
 
 You'll need to install [MinGW](http://www.mingw.org/) and [add it to your PATH](http://www.howtogeek.com/118594/how-to-edit-your-system-path-for-easy-command-line-access/).
 
+**Make sure to restart Atom after adding it to your PATH**
+
 ### Mac
 
 You'll need to install [XCode](https://developer.apple.com/xcode/).


### PR DESCRIPTION
This should reduce the number of issues being opened about Atom not being able to find a compiler. Restarting Atom restarts its console session so it can use the updated PATH settings.