### PR TITLE
Resolution of a bug in auto execution on win32

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,7 +306,7 @@ function compile(command, info, args, gdb) {
           // cmd to run the program
           const file = getTmp(info.name);
 
-          child_process.exec(`start "${info.name}" cmd /C "${gdb ? "gdb" : ""} ${file} ${gdb ? "" : "& echo. & pause"}`, options);
+          child_process.exec(`start "${info.name}" cmd /C "${gdb ? "gdb" : ""} "${file}" ${gdb ? "" : "& echo. & pause"}`, options);
         } else if (process.platform === "darwin") {
           // if the platform is mac, spawn open, which does the same thing as
           // Windows' start, but is not a builtin, so we can child_process.spawn


### PR DESCRIPTION
On windows, if the "compile to temporary directory" option is disabled and the source code path contains spaces (and so the executable will) auto execution doesn't work: resolved adding quotes around ${file} in the execution command