### PR TITLE
Fix "Callback must be a function. Received undefined" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,7 +296,7 @@ function compile(command, info, args, gdb) {
         addError(stderr.replace(/\n/g, "<br/>"));
 
       if (atom.config.get("gpp-compiler.addCompilingErr")) {
-        fs.writeFile(path.join(info.dir, "compiling_error.txt"), stderr, e => console.log(e));
+        fs.writeFileSync(path.join(info.dir, "compiling_error.txt"), stderr);
       }
     } else {
       // compilation was successful, but there still may be warnings
@@ -424,7 +424,7 @@ function compile(command, info, args, gdb) {
       // it exists
       fs.stat(path.join(info.dir, "compiling_error.txt"), (err) => {
         if (!err) {
-          fs.unlink(path.join(info.dir, "compiling_error.txt"), e => console.log(e));
+          fs.unlinkSync(path.join(info.dir, "compiling_error.txt"));
         }
       });
     }

--- a/index.js
+++ b/index.js
@@ -296,7 +296,7 @@ function compile(command, info, args, gdb) {
         addError(stderr.replace(/\n/g, "<br/>"));
 
       if (atom.config.get("gpp-compiler.addCompilingErr")) {
-        fs.writeFile(path.join(info.dir, "compiling_error.txt"), stderr);
+        fs.writeFile(path.join(info.dir, "compiling_error.txt"), stderr, e => console.log(e));
       }
     } else {
       // compilation was successful, but there still may be warnings
@@ -424,7 +424,7 @@ function compile(command, info, args, gdb) {
       // it exists
       fs.stat(path.join(info.dir, "compiling_error.txt"), (err) => {
         if (!err) {
-          fs.unlink(path.join(info.dir, "compiling_error.txt"));
+          fs.unlink(path.join(info.dir, "compiling_error.txt"), e => console.log(e));
         }
       });
     }


### PR DESCRIPTION
Many users have reported the following error: `Callback must be a function. Received undefined`.
This error was caused by asynchronous fs method calls that did not include a callback. The issue has been fixed by calling the synchronous variants of the methods instead, since those do not require a callback.